### PR TITLE
improve GC-friendliness of fromTypedArray

### DIFF
--- a/src/mimefuncs.js
+++ b/src/mimefuncs.js
@@ -473,18 +473,19 @@
          * @return {String} 'binary' string
          */
         fromTypedArray: function(buf) {
-            var i, l, str = '';
+            var i, l;
 
             // ensure the value is a Uint8Array, not ArrayBuffer if used
             if (!buf.buffer) {
                 buf = new Uint8Array(buf);
             }
 
+            var sbits = new Array(buf.length);
             for (i = 0, l = buf.length; i < l; i++) {
-                str += String.fromCharCode(buf[i]);
+                sbits[i] = String.fromCharCode(buf[i]);
             }
 
-            return str;
+            return sbits.join('');
         },
 
         /**


### PR DESCRIPTION
In the Firefox OS email app we noticed a regression in garbage
generation for attachment downloads correlated to our switch to the
email.js libraries.

Long story short, using the implementation prior to this patch, we saw
VERY rapid heap usage.  This patch changes the technique used to the
one we used in the Firefox OS email app prior to the email.js change.

Although GC implications aren't always obvious, I think there are a
number of straightforward reasons to prefer this approach:

- fromCharCode results can potentially be reused by the JS VM since
  JS strings are immutable
- It results in less string objects; the solution prior to this patch
  already was creating fromCharCode objects, but was also then creating
  O(l) intermediary strings.  Even with a rope-based implementation
  (which is what SpiderMonkey does until it wants to flatten a string)
  the per-object overhead is quite high.

And perhaps less straightforward, but maybe a real thing:
- In rope-based implementations (SpiderMonkey), an append-based string
  built on O(l) append operations could be significantly more expensive
  than the same string built freshly with array.join('').
- I'm pretty sure JS-engine people have told us to do things this way,
  unfortunately I don't have direct links to any such advice.

On my on-device test, this small change resulted in our process heap
growing at less than half the rate of the pre-patch fix.